### PR TITLE
Gets rid of trailing whitespace in seed

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -767,15 +767,15 @@ fn get_seed(s: &mut Cursive) {
             )
             .h_align(HAlign::Center)
             .button("Done", |s| {
-                let mut seed = s
+                let raw_seed = s
                     .call_on_name("seed", |view: &mut EditView| view.get_content())
                     .unwrap();
-                seed = std::rc::Rc::new(seed.trim().to_string());
+                let seed = raw_seed.trim();
                 if seed.len() != 64 {
                     s.add_layer(Dialog::info("Seed was invalid: not 64 characters long."));
                     return;
                 }
-                let bytes_opt = hex::decode(&*seed);
+                let bytes_opt = hex::decode(seed);
                 if bytes_opt.is_err() {
                     s.add_layer(Dialog::info("Seed was invalid: failed to decode hex."));
                     return;

--- a/src/main.rs
+++ b/src/main.rs
@@ -767,9 +767,10 @@ fn get_seed(s: &mut Cursive) {
             )
             .h_align(HAlign::Center)
             .button("Done", |s| {
-                let seed = s
+                let mut seed = s
                     .call_on_name("seed", |view: &mut EditView| view.get_content())
                     .unwrap();
+                seed = std::rc::Rc::new(seed.trim().to_string());
                 if seed.len() != 64 {
                     s.add_layer(Dialog::info("Seed was invalid: not 64 characters long."));
                     return;


### PR DESCRIPTION
Before, if there was trailing whitespace in the seed, the character check would fail due to not being 64 characters long. Now, the white space is trimmed. I `cargo build`ed and tested, seems to work.