### PR TITLE
v1.0.0 Beta

### DIFF
--- a/src/accounts.rs
+++ b/src/accounts.rs
@@ -1,0 +1,486 @@
+use super::*;
+use aes_gcm::aead::{generic_array::GenericArray, Aead, NewAead};
+use aes_gcm::{Aes256Gcm, Nonce};
+use argon2::{self, Config};
+
+const SALT_LENGTH: usize = 16;
+const IV_LENGTH: usize = 12;
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct Account {
+    pub mnemonic: Option<String>,
+    pub seed: Option<[u8; 32]>,
+    pub key_idx: u128,
+    pub private_key: [u8; 32],
+    pub public_key: [u8; 32],
+    pub address: String,
+    pub balance: u128,
+    pub receivables: Vec<Receivable>,
+}
+
+impl Account {
+    fn from_mnemonic(mnemonic: Option<String>, seed: Option<[u8; 32]>, prefix: &str) -> Account {
+        let (private_key, public_key) = Account::get_keypair(&seed.unwrap());
+        Account {
+            mnemonic,
+            seed,
+            key_idx: 0,
+            private_key,
+            public_key,
+            address: dcutil::get_address(&public_key, prefix),
+            balance: 0,
+            receivables: vec![],
+        }
+    }
+    fn from_seed(seed: Option<[u8; 32]>, prefix: &str) -> Account {
+        let (private_key, public_key) = Account::get_keypair(&seed.unwrap());
+        Account {
+            mnemonic: None,
+            seed,
+            key_idx: 0,
+            private_key,
+            public_key,
+            address: dcutil::get_address(&public_key, prefix),
+            balance: 0,
+            receivables: vec![],
+        }
+    }
+
+    fn from_private_key(private_key: [u8; 32], prefix: &str) -> Account {
+        let public_key = Account::get_public_key(&private_key);
+        Account {
+            mnemonic: None,
+            seed: None,
+            key_idx: 0,
+            private_key,
+            public_key,
+            address: dcutil::get_address(&public_key, prefix),
+            balance: 0,
+            receivables: vec![],
+        }
+    }
+
+    fn get_keypair(seed: &[u8; 32]) -> ([u8; 32], [u8; 32]) {
+        let private_key = dcutil::get_private_key(seed);
+        let public_key = Account::get_public_key(&private_key);
+        (private_key, public_key)
+    }
+    fn get_public_key(private_key: &[u8; 32]) -> [u8; 32] {
+        let dalek = ed25519_dalek::SecretKey::from_bytes(private_key).unwrap();
+        let public_key = ed25519_dalek::PublicKey::from(&dalek);
+        public_key.to_bytes()
+    }
+}
+
+pub fn check_setup(s: &mut Cursive) {
+    if let Some(mut data_dir) = dirs::data_dir() {
+        data_dir = data_dir.join("dagchat");
+        if data_dir.exists() {
+            load_accounts(s, data_dir);
+        } else {
+            fs::create_dir(data_dir.clone()).unwrap_or_else(|e| {
+                let content = format!(
+                    "Failed to create a data folder for dagchat at path: {:?}\nError: {}",
+                    data_dir, e
+                );
+                s.add_layer(Dialog::info(content))
+            });
+            if data_dir.exists() {
+                load_accounts(s, data_dir);
+            } else {
+                return;
+            }
+        }
+    } else {
+        s.add_layer(Dialog::info(
+            "Error locating the application data folder on your system.",
+        ));
+    }
+}
+
+fn load_accounts(s: &mut Cursive, data_path: PathBuf) {
+    s.pop_layer();
+    let accounts_file = data_path.join("accounts.dagchat");
+    if accounts_file.exists() {
+        let encrypted_bytes = fs::read(&accounts_file).unwrap_or_else(|e| {
+            let content = format!(
+                "Failed to read accounts.dagchat file at path: {:?}\nError: {}",
+                accounts_file.display(),
+                e
+            );
+            s.add_layer(Dialog::info(content));
+            vec![]
+        });
+        if encrypted_bytes.is_empty() {
+            show_accounts(s);
+            return;
+        }
+        s.add_layer(Dialog::around(
+            LinearLayout::vertical()
+                .child(TextView::new("Enter password:"))
+                .child(TextArea::new().with_name("password").max_width(80))
+                .child(Button::new("Submit", move |s| {
+                    let mut password = String::from("");
+                    s.call_on_name("password", |view: &mut TextArea| {
+                        password = String::from(view.get_content());
+                    });
+
+                    let bytes = decrypt_accounts(&encrypted_bytes, &password);
+                    if bytes.is_none() {
+                        s.add_layer(Dialog::info("Incorrect password."));
+                        return;
+                    }
+                    let data = &mut s.user_data::<UserData>().unwrap();
+                    data.password = password;
+                    data.accounts = bincode::deserialize(&bytes.unwrap()[..]).unwrap();
+                    show_accounts(s);
+                })),
+        ));
+    } else {
+        show_accounts(s);
+    }
+}
+
+fn write_accounts(encrypted_bytes: Vec<u8>) -> bool {
+    let mut success = false;
+    if let Some(data_dir) = dirs::data_dir() {
+        let accounts_file = data_dir.join("dagchat/accounts.dagchat");
+        if !accounts_file.exists() {
+            fs::File::create(&accounts_file).expect(&format!(
+                "Unable to create accounts.dagchat at path: {:?}",
+                &accounts_file
+            ));
+        }
+        if accounts_file.exists() {
+            success = true;
+            fs::write(&accounts_file, encrypted_bytes).unwrap_or_else(|e| {
+                success = false;
+                eprintln!(
+                    "Failed to write to accounts.dagchat file at path: {:?}\nError: {}",
+                    accounts_file, e
+                );
+            });
+        }
+    }
+    success
+}
+
+fn save_accounts(s: &mut Cursive) {
+    let data = &s.user_data::<UserData>().unwrap();
+    let success: bool;
+    if data.accounts.is_empty() {
+        success = write_accounts(vec![]);
+    } else {
+        let encrypted_bytes = encrypt_accounts(&data.accounts, &data.password);
+        success = write_accounts(encrypted_bytes);
+    }
+    if !success {
+        s.add_layer(Dialog::info("Error saving accounts data."));
+    }
+}
+
+fn derive_key(password: &str, salt: &[u8]) -> Vec<u8> {
+    let config = Config::default();
+    let hash = argon2::hash_raw(password.as_bytes(), salt, &config).unwrap();
+    hash
+}
+
+fn encrypt_accounts(accounts: &Vec<Account>, password: &str) -> Vec<u8> {
+    let mut csprng = rand::thread_rng();
+    let mut salt = [0u8; SALT_LENGTH];
+    csprng.fill_bytes(&mut salt);
+
+    let key_bytes = derive_key(password, &salt);
+    let key = GenericArray::from_slice(&key_bytes);
+    let encoded: Vec<u8> = bincode::serialize(accounts).unwrap();
+    let aead = Aes256Gcm::new(key);
+
+    let mut nonce_bytes = [0u8; 12];
+    csprng.fill_bytes(&mut nonce_bytes);
+    let nonce = Nonce::from_slice(&nonce_bytes);
+
+    let ciphertext = aead.encrypt(nonce, &encoded[..]).unwrap();
+    let mut encrypted_bytes = Vec::with_capacity(12 + ciphertext.len());
+    encrypted_bytes.extend(salt);
+    encrypted_bytes.extend(nonce);
+    encrypted_bytes.extend(ciphertext);
+    encrypted_bytes
+}
+
+fn decrypt_accounts(encrypted_bytes: &[u8], password: &str) -> Option<Vec<u8>> {
+    let salt = &encrypted_bytes[..SALT_LENGTH];
+
+    let key_bytes = derive_key(password, salt);
+    let key = GenericArray::from_slice(&key_bytes);
+
+    let aead = Aes256Gcm::new(&key);
+    let nonce = Nonce::from_slice(&encrypted_bytes[SALT_LENGTH..SALT_LENGTH + IV_LENGTH]);
+    let encrypted = &encrypted_bytes[SALT_LENGTH + IV_LENGTH..];
+    let decrypted = aead.decrypt(nonce, encrypted);
+    if decrypted.is_err() {
+        return None;
+    }
+    Some(decrypted.unwrap())
+}
+
+pub fn show_accounts(s: &mut Cursive) {
+    s.pop_layer();
+    let data: UserData = s.take_user_data().unwrap();
+    //Scroll view on left, iter on accounts and show them all
+    //Have 'Guest' button
+    //Have add, remove account, change password buttons on right
+    //When importing seed/mnemonic, option to specify index
+    let buttons = LinearLayout::vertical()
+        .child(Button::new("Add account", |s| add_account(s)))
+        .child(Button::new("Remove account", |s| remove_account(s)));
+
+    let select = SelectView::<String>::new()
+        .on_submit(select_account)
+        .with_name("accounts")
+        .scrollable()
+        .max_height(10);
+
+    s.add_layer(
+        Dialog::around(
+            LinearLayout::horizontal()
+                .child(select)
+                .child(DummyView)
+                .child(buttons),
+        )
+        .title("Select account"),
+    );
+
+    let mut i = 1;
+    for account in &data.accounts {
+        let tag;
+        if account.mnemonic.is_some() {
+            tag = format!("{}. From mnemonic", i);
+        } else if account.seed.is_some() {
+            tag = format!("{}. From seed", i);
+        } else {
+            tag = format!("{}. From private key", i);
+        }
+        s.call_on_name("accounts", |view: &mut SelectView<String>| {
+            view.add_item_str(&tag)
+        });
+        i += 1;
+    }
+
+    s.set_user_data(data);
+}
+
+fn select_account(s: &mut Cursive, name: &str) {
+    let select = s.find_name::<SelectView<String>>("accounts").unwrap();
+    match select.selected_id() {
+        None => s.add_layer(Dialog::info("No account selected.")),
+        Some(focus) => {
+            // If from mnemonic or seed, let user choose id. Else start.
+            let data = &mut s.user_data::<UserData>().unwrap();
+            data.acc_idx = focus;
+            receive::load_receivables(s);
+        }
+    }
+}
+
+fn remove_account(s: &mut Cursive) {
+    let select = s.find_name::<SelectView<String>>("accounts").unwrap();
+    match select.selected_id() {
+        None => s.add_layer(Dialog::info("No account selected.")),
+        Some(focus) => {
+            // Add backup button to copy mnemonic/seed to clip
+            s.add_layer(Dialog::around(TextView::new("Confirm account deletion. If you have not backed up this account, it will be lost forever.").max_width(80))
+                .button("Confirm", move |s| {
+                    let data = &mut s.user_data::<UserData>().unwrap();
+                    data.accounts.remove(focus);
+                    save_accounts(s);
+                    s.pop_layer();
+                    show_accounts(s);
+                })
+                .button("Back", |s| {
+                    s.pop_layer();
+                })
+            );
+        }
+    }
+}
+
+fn add_account(s: &mut Cursive) {
+    s.pop_layer();
+    let data = &s.user_data::<UserData>().unwrap();
+    let coin = &data.coin.name;
+    let colour = data.coin.colour;
+    let content = format!("Choose a way to import your {} wallet.", coin);
+    s.add_layer(
+        Dialog::text(StyledString::styled(content, colour))
+            .title("Import account")
+            .h_align(HAlign::Center)
+            .button("Mnemonic", |s| from_mnemonic(s))
+            .button("Seed", |s| from_seed_or_key(s, String::from("seed")))
+            .button("New", |s| new_account(s)),
+    );
+}
+
+fn from_mnemonic(s: &mut Cursive) {
+    s.pop_layer();
+    s.add_layer(
+        Dialog::new()
+            .title("Enter your 24 word mnemonic")
+            .padding_lrtb(1, 1, 1, 0)
+            .content(EditView::new().with_name("mnemonic").fixed_width(29))
+            .h_align(HAlign::Center)
+            .button("Done", |s| {
+                let mnemonic = s
+                    .call_on_name("mnemonic", |view: &mut EditView| view.get_content())
+                    .unwrap();
+                let seed = validate_mnemonic(&mnemonic);
+                let content;
+                s.pop_layer();
+                if !mnemonic.is_empty() && seed.is_some() {
+                    let seed_bytes = seed.unwrap();
+                    let data = &s.user_data::<UserData>().unwrap();
+                    let account = Account::from_mnemonic(
+                        Some(String::from(&*mnemonic)),
+                        Some(seed_bytes),
+                        &data.coin.prefix,
+                    );
+                    setup_account(s, account, |s| {
+                        import_success(s, "Successfully imported account from mnemonic phrase.")
+                    });
+                } else {
+                    content = "The mnemonic you entered was not valid.";
+                    s.add_layer(
+                        Dialog::around(TextView::new(content)).button("Back", |s| from_mnemonic(s)),
+                    );
+                    return;
+                }
+            })
+            .button("Paste", |s| {
+                s.call_on_name("mnemonic", |view: &mut EditView| {
+                    let mut clipboard = Clipboard::new().unwrap();
+                    let clip = clipboard
+                        .get_text()
+                        .unwrap_or_else(|_| String::from("Failed to read clipboard."));
+                    view.set_content(clip);
+                })
+                .unwrap();
+            })
+            .button("Back", |s| {
+                show_accounts(s);
+            }),
+    );
+}
+
+fn from_seed_or_key(s: &mut Cursive, seed_or_key: String) {
+    s.pop_layer();
+    s.add_layer(
+        Dialog::new()
+            .title(format!("Enter your {}", seed_or_key))
+            .padding_lrtb(1, 1, 1, 0)
+            .content(EditView::new().with_name("seedorkey").fixed_width(29))
+            .h_align(HAlign::Center)
+            .button("Done", move |s| {
+                let raw_seedorkey = s
+                    .call_on_name("seedorkey", |view: &mut EditView| view.get_content())
+                    .unwrap();
+                let seedorkey = raw_seedorkey.trim();
+                if seedorkey.len() != 64 {
+                    s.add_layer(Dialog::info(format!(
+                        "Error: {} was invalid - not 64 characters long.",
+                        seed_or_key
+                    )));
+                    return;
+                }
+                let bytes_opt = hex::decode(seedorkey);
+                if bytes_opt.is_err() {
+                    s.add_layer(Dialog::info(format!(
+                        "Error: {} was invalid - failed to decode hex.",
+                        seed_or_key
+                    )));
+                    return;
+                }
+                let bytes = bytes_opt.unwrap();
+                let seedorkey_bytes: [u8; 32] = bytes.try_into().unwrap();
+                let data = &s.user_data::<UserData>().unwrap();
+                let account: Account;
+                if seed_or_key == "seed" {
+                    account = Account::from_seed(Some(seedorkey_bytes), &data.coin.prefix);
+                } else {
+                    account = Account::from_private_key(seedorkey_bytes, &data.coin.prefix);
+                }
+                let content = format!("Successfully imported account from {}.", seed_or_key);
+                setup_account(s, account, move |s| import_success(s, &content));
+            })
+            .button("Paste", |s| {
+                s.call_on_name("seedorkey", |view: &mut EditView| {
+                    let mut clipboard = Clipboard::new().unwrap();
+                    let clip = clipboard
+                        .get_text()
+                        .unwrap_or_else(|_| String::from("Failed to read clipboard."));
+                    view.set_content(clip);
+                })
+                .unwrap();
+            })
+            .button("Back", |s| {
+                show_accounts(s);
+            }),
+    );
+}
+
+fn new_account(s: &mut Cursive) {
+    s.pop_layer();
+    let data = &s.user_data::<UserData>().unwrap();
+    let mut csprng = rand::thread_rng();
+    let mut seed_bytes = [0u8; 32];
+    csprng.fill_bytes(&mut seed_bytes);
+    let account = Account::from_seed(Some(seed_bytes), &data.coin.prefix);
+    setup_account(s, account, move |s| new_success(s, hex::encode(seed_bytes)));
+}
+
+fn setup_account<F: 'static>(s: &mut Cursive, account: Account, on_success: F)
+where
+    F: Fn(&mut Cursive),
+{
+    let data = &mut s.user_data::<UserData>().unwrap();
+    data.accounts.push(account);
+
+    // First account added, setup password
+    if data.accounts.len() == 1 {
+        s.add_layer(Dialog::around(
+            LinearLayout::vertical()
+                .child(TextView::new("Create a password. If you forget this, you will not be able to restore your accounts so make sure you have backed up the mnemonic phrases, seeds or private keys of your accounts.").max_width(80))
+                .child(TextArea::new().with_name("password").max_width(80))
+                .child(Button::new("Submit", move |s| {
+                    let mut password = String::from("");
+                    s.call_on_name("password", |view: &mut TextArea| {
+                        password = String::from(view.get_content());
+                    });
+                    let data = &mut s.user_data::<UserData>().unwrap();
+                    data.password = password;
+                    save_accounts(s);
+                    s.pop_layer();
+                    on_success(s);
+                }))));
+    } else {
+        save_accounts(s);
+        on_success(s);
+    }
+}
+
+fn import_success(s: &mut Cursive, content: &str) {
+    s.add_layer(
+        Dialog::around(TextView::new(content).max_width(80))
+            .button("Begin", |s| alpha_info(s))
+            .button("Back", |s| show_accounts(s)),
+    );
+}
+
+fn new_success(s: &mut Cursive, seed: String) {
+    let mut content = StyledString::plain("Successfully generated new account with seed: ");
+    content.append(StyledString::styled(&seed, OFF_WHITE));
+    s.add_layer(
+        Dialog::around(TextView::new(content).max_width(80))
+            .button("Copy seed", move |s| copy_to_clip(s, seed.clone()))
+            .button("Begin", |s| alpha_info(s))
+            .button("Back", |s| show_accounts(s)),
+    );
+}

--- a/src/dcutil.rs
+++ b/src/dcutil.rs
@@ -133,7 +133,6 @@ pub struct BlocksResponse {
     data: HashMap<String, BlockResponse>,
 }
 
-
 #[derive(Serialize, Deserialize, Debug)]
 pub struct BlocksInfoResponse {
     blocks: BlocksResponse,
@@ -174,13 +173,12 @@ pub fn send_message(
     }
     let public_key = ecies_ed25519::PublicKey::from_bytes(&public_key_bytes).unwrap();
     counter.tick(50);
-    //println!("Encrypting message for send: {}", message);
+
     let mut csprng = rand::thread_rng();
     let encrypted_bytes =
         ecies_ed25519::encrypt(&public_key, message.as_bytes(), &mut csprng).unwrap();
     let blocks_needed = ((60 + message.len()) / 32) + 1;
     counter.tick(50);
-    //println!("Blocks needed: {}", blocks_needed);
 
     let mut block_data = [0u8; 32];
     let mut first_block_hash = [0u8; 32];
@@ -217,7 +215,6 @@ pub fn send_message(
         } else {
             block_data.copy_from_slice(&encrypted_bytes[start..end]);
         }
-        //println!("Block data as addr: {:?}", get_address(&block_data, addr_prefix));
         let block_hash = get_block_hash(
             private_key_bytes,
             &block_data,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use arboard::Clipboard;
+use bincode;
 use cursive::align::HAlign;
 use cursive::theme::{BaseColor, BorderStyle, Color, PaletteColor, Theme};
 use cursive::traits::*;
@@ -8,62 +9,77 @@ use cursive::views::{
     TextArea, TextView,
 };
 use cursive::Cursive;
+use dirs;
 use rand::RngCore;
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::PathBuf;
 
 pub mod defaults;
 use defaults::SHOW_TO_DP;
 
-// Dagchat util
+// dagchat util
 mod dcutil;
 use dcutil::*;
 
-pub struct Data {
-    pub account: Account,
-    pub prefix: String,
-    pub coin: String,
-    pub ticker: String,
-    pub multiplier: String,
-    pub node_url: String,
-    pub colour: Color,
+// dagchat accounts util
+mod accounts;
+
+// send and receive with dagchat
+mod receive;
+mod send;
+
+pub struct UserData {
+    pub password: String,
+    pub accounts: Vec<accounts::Account>,
+    pub acc_idx: usize,
+    pub coin: Coin,
 }
 
-pub struct Account {
-    pub entropy: [u8; 32],
-    pub private_key: [u8; 32],
-    pub public_key: [u8; 32],
-    pub address: String,
-    pub balance: u128,
-    pub receivables: Vec<Receivable>,
+pub struct Coin {
+    prefix: String,
+    name: String,
+    ticker: String,
+    multiplier: String,
+    node_url: String,
+    colour: Color,
 }
 
-impl Default for Account {
-    fn default() -> Account {
-        Account {
-            entropy: [0u8; 32],
-            private_key: [0u8; 32],
-            public_key: [0u8; 32],
-            address: String::from(""),
-            balance: 0,
-            receivables: Vec::new(),
-        }
-    }
-}
-
-impl Data {
-    pub fn new() -> Self {
-        Data {
-            account: Default::default(),
+impl Coin {
+    fn nano() -> Coin {
+        Coin {
             prefix: String::from("nano_"),
-            coin: String::from("nano"),
+            name: String::from("nano"),
             ticker: String::from("Ӿ"),
             multiplier: String::from("1000000000000000000000000000000"),
             node_url: String::from("https://app.natrium.io/api"),
             colour: L_BLUE,
         }
     }
+    fn banano() -> Coin {
+        Coin {
+            prefix: String::from("ban_"),
+            name: String::from("banano"),
+            ticker: String::from(" BAN"),
+            multiplier: String::from("100000000000000000000000000000"),
+            node_url: String::from("https://kaliumapi.appditto.com/api"),
+            colour: YELLOW,
+        }
+    }
 }
 
-const VERSION: &str = "alpha v1.0.0";
+impl UserData {
+    pub fn new() -> Self {
+        UserData {
+            password: String::from(""),
+            accounts: vec![],
+            acc_idx: 0,
+            coin: Coin::nano(),
+        }
+    }
+}
+
+const VERSION: &str = "beta v1.0.0";
 
 const L_BLUE: Color = Color::Rgb(62, 138, 227);
 const M_BLUE: Color = Color::Rgb(0, 106, 255);
@@ -81,7 +97,7 @@ fn main() {
 
     let mut siv = cursive::default();
     siv.set_window_title(format!("dagchat {}", VERSION));
-    let data = Data::new();
+    let data = UserData::new();
     siv.set_user_data(data);
     set_theme(&mut siv, "nano", false);
 
@@ -107,17 +123,11 @@ fn main() {
         let vibrant = theme_group.selection();
         set_theme(s, &*coin, *vibrant);
         if *coin == "banano" {
-            s.with_user_data(|data: &mut Data| {
-                data.prefix = String::from("ban_");
-                data.coin = String::from("banano");
-                data.ticker = String::from(" BAN");
-                // Down to 10^29 from 10^30
-                data.multiplier.pop();
-                data.node_url = String::from("https://kaliumapi.appditto.com/api");
-                data.colour = YELLOW;
+            s.with_user_data(|data: &mut UserData| {
+                data.coin = Coin::banano();
             });
         }
-        show_start(s)
+        accounts::check_setup(s);
     });
 
     siv.add_layer(
@@ -135,295 +145,22 @@ fn main() {
     siv.try_run_with(backend_init).ok().unwrap();
 }
 
-fn show_start(s: &mut Cursive) {
-    s.pop_layer();
-    let data = &s.user_data::<Data>().unwrap();
-    let coin = &data.coin;
-    let colour = data.colour;
-    let content = format!("Choose a way to import your {} wallet", coin);
-    s.add_layer(
-        Dialog::text(StyledString::styled(content, colour))
-            .title("Import account")
-            .h_align(HAlign::Center)
-            .button("Mnemonic", |s| get_mnemonic(s))
-            .button("Seed", |s| get_seed(s))
-            .button("New", |s| new_account(s)),
-    );
-}
-
-fn show_send(s: &mut Cursive, with_message: bool) {
-    s.pop_layer();
-
-    let data = &s.user_data::<Data>().unwrap();
-    let balance = data.account.balance;
-    let coin = data.coin.clone();
-    let ticker = data.ticker.clone();
-    let multiplier = data.multiplier.clone();
-    
-
-    if balance == 0 {
-        let address = data.account.address.clone();
-        let no_balance_message;
-        if with_message {
-            no_balance_message = format!("To send a message with dagchat you need a balance of at least 1 raw - a tiny fraction of a coin. One faucet claim will last you a lifetime. Your address is: {}", address);
-        } else {
-            no_balance_message = format!("You don't have any {} in your wallet to send.", coin);
-        }
-        s.add_layer(
-            Dialog::around(TextView::new(no_balance_message))
-                .h_align(HAlign::Center)
-                .button("Back", |s| show_inbox(s))
-                .button("Copy Address", move |s| copy_to_clip(s, address.clone()))
-                .max_width(75),
-        );
-        return;
-    }
-
-    let sub_title_colour = get_subtitle_colour(s);
-
-    let mut form_content = LinearLayout::vertical()
-        .child(TextView::new(StyledString::styled(
-            "Recipient Address",
-            sub_title_colour,
-        )))
-        .child(TextArea::new().with_name("address").max_width(66))
-        .child(
-            LinearLayout::horizontal()
-                .child(Button::new("Paste", |s| {
-                    s.call_on_name("address", |view: &mut TextArea| {
-                        let mut clipboard = Clipboard::new().unwrap();
-                        let clip = clipboard
-                            .get_text()
-                            .unwrap_or_else(|_| String::from("Failed to read clipboard."));
-                        view.set_content(clip);
-                    })
-                    .unwrap();
-                }))
-                .child(Button::new("Address book", |s| {
-                    s.add_layer(Dialog::info("Coming soon..."));
-                })),
-        )
-        .child(DummyView);
-    let title_content;
-    if with_message {
-        title_content = String::from("Send a message");
-        form_content.add_child(TextView::new(StyledString::styled(
-            "Message Content",
-            sub_title_colour,
-        )));
-        form_content.add_child(TextArea::new().with_name("message").max_width(80));
-        form_content.add_child(DummyView);
-        form_content.add_child(TextView::new(StyledString::styled(
-            format!("Optional {}", ticker),
-            sub_title_colour,
-        )));
-        form_content.add_child(TextArea::new().with_name("amount"));
-    } else {
-        title_content = format!("Send {}", coin);
-        form_content.add_child(TextView::new(StyledString::styled(
-            "Amount",
-            sub_title_colour,
-        )));
-        form_content.add_child(TextArea::new().with_name("amount"));
-    }
-    form_content.add_child(DummyView);
-    form_content.add_child(
-        LinearLayout::horizontal()
-            .child(Button::new("Send", move |s| {
-                let mut address = String::from("");
-                let mut message = String::from("");
-                let mut amount = String::from("");
-                s.call_on_name("address", |view: &mut TextArea| {
-                    address = String::from(view.get_content());
-                })
-                .unwrap();
-                if with_message {
-                    s.call_on_name("message", |view: &mut TextArea| {
-                        message = String::from(view.get_content());
-                    })
-                    .unwrap();
-                    if message.trim().is_empty() {
-                        s.add_layer(Dialog::info(
-                            "You must provide message content to send a message!",
-                        ));
-                        return;
-                    }
-                }
-                s.call_on_name("amount", |view: &mut TextArea| {
-                    amount = String::from(view.get_content());
-                })
-                .unwrap();
-                if address.is_empty() {
-                    let content;
-                    if with_message {
-                        content =
-                            String::from("You must provide an address to send the message to!");
-                    } else {
-                        content = format!("You must provide an address to send {} to!", coin);
-                    }
-                    s.add_layer(Dialog::info(content));
-                    return;
-                }
-                let valid = validate_address(&address);
-                if !valid {
-                    s.add_layer(Dialog::info("The recipient's address is invalid."));
-                    return;
-                }
-                let mut raw: u128 = 0;
-                if with_message {
-                    raw = 1;
-                }
-                if !amount.is_empty() {
-                    let raw_opt = whole_to_raw(amount, &multiplier);
-                    if raw_opt.is_none() {
-                        let content;
-                        if with_message {
-                            content = "The optional amount was invalid.";
-                        } else {
-                            content = "The amount was invalid.";
-                        }
-                        s.add_layer(Dialog::info(content));
-                        return;
-                    }
-                    raw = raw_opt.unwrap();
-                    if raw > balance {
-                        s.add_layer(Dialog::info(
-                            "The amount you want to send is more than your account balance!",
-                        ));
-                        return;
-                    } else {
-                        // The user supplied the amount 0
-                        if raw == 0 {
-                            s.add_layer(Dialog::info(format!(
-                                "You must provide an amount of {} to send!",
-                                coin
-                            )));
-                            return;
-                        }
-                    }
-                } else {
-                    if message.is_empty() {
-                        // The user supplied no amount and it's not a message
-                        s.add_layer(Dialog::info(format!(
-                            "You must provide an amount of {} to send!",
-                            coin
-                        )));
-                        return;
-                    }
-                }
-                process_send(s, raw, address, message);
-            }))
-            .child(Button::new("Cancel", |s| show_inbox(s))),
-    );
-    s.add_layer(
-        Dialog::around(form_content)
-            .title(title_content)
-            .padding_lrtb(1, 1, 1, 0),
-    );
-}
+// Functions below are used across main.rs, send.rs,
+// receive.rs and accounts.rs
 
 fn go_back(s: &mut Cursive) {
     s.pop_layer();
 }
 
 fn get_subtitle_colour(s: &mut Cursive) -> Color {
-    let data = &s.user_data::<Data>().unwrap();
+    let data = &s.user_data::<UserData>().unwrap();
     let sub_title_colour;
-    if data.colour == YELLOW {
+    if data.coin.colour == YELLOW {
         sub_title_colour = OFF_WHITE;
     } else {
-        sub_title_colour = data.colour;
+        sub_title_colour = data.coin.colour;
     }
     sub_title_colour
-}
-
-fn process_send(s: &mut Cursive, raw: u128, address: String, message: String) {
-    let ticks = 1000;
-    let cb = s.cb_sink().clone();
-    let data = &mut s.user_data::<Data>().unwrap();
-    let node_url = data.node_url.clone();
-    let private_key_bytes = data.account.private_key;
-    let prefix = data.prefix.clone();
-    s.pop_layer();
-    s.add_layer(Dialog::around(
-        ProgressBar::new()
-            .range(0, ticks)
-            .with_task(move |counter| {
-                let with_message = !message.is_empty();
-                if !with_message {
-                    send(
-                        &private_key_bytes,
-                        address,
-                        raw,
-                        &node_url,
-                        &prefix,
-                        &counter,
-                    );
-                } else {
-                    send_message(
-                        &private_key_bytes,
-                        address,
-                        raw,
-                        message,
-                        &node_url,
-                        &prefix,
-                        &counter,
-                    );
-                }
-                cb.send(Box::new(move |s| {
-                    let data = &mut s.user_data::<Data>().unwrap();
-                    data.account.balance -= raw;
-                    show_sent(s, with_message);
-                }))
-                .unwrap();
-            })
-            .full_width(),
-    ));
-    s.set_autorefresh(true);
-}
-
-fn process_receive(s: &mut Cursive, idx: usize) {
-    let data = &mut s.user_data::<Data>().unwrap();
-    let private_key = data.account.private_key;
-    let send_block_hash = data.account.receivables[idx].hash.clone();
-    let amount = data.account.receivables[idx].amount;
-    let address = data.account.address.clone();
-    let prefix = data.prefix.clone();
-    let node_url = data.node_url.clone();
-    let ticks = 1000;
-    let cb = s.cb_sink().clone();
-    s.add_layer(Dialog::around(
-        ProgressBar::new()
-            .range(0, ticks)
-            .with_task(move |counter| {
-                counter.tick(100);
-                receive_block(
-                    &private_key,
-                    &send_block_hash,
-                    amount,
-                    &address,
-                    &node_url,
-                    &prefix,
-                    &counter,
-                );
-                cb.send(Box::new(move |s| {
-                    let mut select = s.find_name::<SelectView<String>>("select").unwrap();
-                    select.remove_item(idx);
-                    let mut balance = s.find_name::<TextView>("balance").unwrap();
-                    let data = &mut s.user_data::<Data>().unwrap();
-                    data.account.receivables.remove(idx);
-                    data.account.balance += amount;
-                    let bal = display_to_dp(data.account.balance, SHOW_TO_DP, &data.multiplier, &data.ticker);
-                    let bal_text = format!("Balance: {}", bal);
-                    balance.set_content(StyledString::styled(bal_text, data.colour));
-                    s.pop_layer();
-                    s.pop_layer();
-                }))
-                .unwrap();
-            })
-            .full_width(),
-    ));
-    s.set_autorefresh(true);
 }
 
 fn alpha_info(s: &mut Cursive) {
@@ -432,64 +169,19 @@ fn alpha_info(s: &mut Cursive) {
     info.append(StyledString::styled("This is the inbox. Messages sent to you with 1 raw have already been identified as messages, but messages sent with an arbitrary amount will not yet have been detected. Select 'Find messages' from the buttons on the right to scan your list of receivables and identify these.", OFF_WHITE));
     s.add_layer(
         Dialog::around(TextView::new(info))
-            .button("Go to inbox", |s| load_receivables(s))
+            .button("Go to inbox", |s| receive::load_receivables(s))
             .max_width(60),
     );
 }
 
-fn show_sent(s: &mut Cursive, with_message: bool) {
-    s.set_autorefresh(false);
-    s.pop_layer();
-    let content;
-    if with_message {
-        content = "Message sent successfully!";
-    } else {
-        content = "Sent successfully!";
-    }
-    s.add_layer(Dialog::text(content).button("Back", |s| show_inbox(s)));
-}
-
-fn load_receivables(s: &mut Cursive) {
-    let ticks = 1000;
-
-    let cb = s.cb_sink().clone();
-
-    let data = &s.user_data::<Data>().unwrap();
-    let node_url = data.node_url.clone();
-    let target_address = data.account.address.clone();
-    s.pop_layer();
-    s.add_layer(Dialog::around(
-        ProgressBar::new()
-            .range(0, ticks)
-            .with_task(move |counter| {
-                let account_info = get_account_info(&target_address, &node_url);
-                let mut balance: u128 = 0;
-                if account_info.is_some() {
-                    balance = get_balance(&account_info.unwrap());
-                }
-                counter.tick(100);
-                let receivables = find_incoming(&target_address, &node_url, &counter);
-                cb.send(Box::new(move |s| {
-                    let data = &mut s.user_data::<Data>().unwrap();
-                    data.account.receivables = receivables;
-                    data.account.balance = balance;
-                    show_inbox(s);
-                }))
-                .unwrap();
-            })
-            .full_width(),
-    ));
-    s.set_autorefresh(true);
-}
-
 fn show_change_rep(s: &mut Cursive) {
     s.pop_layer();
-    let data = &mut s.user_data::<Data>().unwrap();
-    let private_key = data.account.private_key;
-    let prefix = data.prefix.clone();
-    let node_url = data.node_url.clone();
-    let address = data.account.address.clone();
-    let coin = data.coin.clone();
+    let data = &mut s.user_data::<UserData>().unwrap();
+    let private_key = data.accounts[data.acc_idx].private_key;
+    let prefix = data.coin.prefix.clone();
+    let node_url = data.coin.node_url.clone();
+    let address = data.accounts[data.acc_idx].address.clone();
+    let coin = data.coin.name.clone();
     let sub_title_colour = get_subtitle_colour(s);
     s.add_layer(
         Dialog::around(
@@ -545,7 +237,7 @@ fn show_change_rep(s: &mut Cursive) {
                     show_inbox(s);
                     s.add_layer(Dialog::info("Successfully changed representative!"));
                 }))
-                .child(Button::new("Cancel", |s| show_inbox(s)))),
+                .child(Button::new("Back", |s| show_inbox(s)))),
         )
         .title("Change representative"),
     );
@@ -572,32 +264,37 @@ fn copy_to_clip(s: &mut Cursive, string: String) {
 fn show_inbox(s: &mut Cursive) {
     s.set_autorefresh(false);
     s.pop_layer();
-    let data: Data = s.take_user_data().unwrap();
-    let address = data.account.address.clone();
-    let send_label = format!("Send {}", data.coin);
+    let data: UserData = s.take_user_data().unwrap();
+    let address = data.accounts[data.acc_idx].address.clone();
+    let send_label = format!("Send {}", data.coin.name);
     let buttons = LinearLayout::vertical()
-        .child(Button::new("Refresh", |s| load_receivables(s)))
+        .child(Button::new("Refresh", |s| receive::load_receivables(s)))
         .child(DummyView)
-        .child(Button::new(send_label, |s| show_send(s, false)))
-        .child(Button::new("Send message", |s| show_send(s, true)))
+        .child(Button::new(send_label, |s| send::show_send(s, false)))
+        .child(Button::new("Send message", |s| send::show_send(s, true)))
         .child(DummyView)
         .child(Button::new("Copy address", move |s| {
             copy_to_clip(s, address.clone())
         }))
         .child(Button::new("Change rep", |s| show_change_rep(s)))
         .child(DummyView)
-        .child(Button::new("Quit", |s| s.quit()));
+        .child(Button::new("Accounts", |s| accounts::show_accounts(s)));
 
     let select = SelectView::<String>::new()
-        .on_submit(show_message_info)
+        .on_submit(receive::show_message_info)
         .with_name("select")
         .scrollable()
         .max_height(6);
 
-    let bal = display_to_dp(data.account.balance, SHOW_TO_DP, &data.multiplier, &data.ticker);
+    let bal = display_to_dp(
+        data.accounts[data.acc_idx].balance,
+        SHOW_TO_DP,
+        &data.coin.multiplier,
+        &data.coin.ticker,
+    );
     let bal_text = format!("Balance: {}", bal);
     let bal_content =
-        TextView::new(StyledString::styled(bal_text, data.colour)).with_name("balance");
+        TextView::new(StyledString::styled(bal_text, data.coin.colour)).with_name("balance");
     s.add_layer(
         Dialog::around(
             LinearLayout::horizontal()
@@ -619,12 +316,17 @@ fn show_inbox(s: &mut Cursive) {
         .title(format!("dagchat {}", VERSION)),
     );
 
-    for receivable in &data.account.receivables {
+    for receivable in &data.accounts[data.acc_idx].receivables {
         let mut tag;
         if receivable.amount == 1 && receivable.message.is_some() {
             tag = String::from("Message");
         } else {
-            tag = display_to_dp(receivable.amount, SHOW_TO_DP, &data.multiplier, &data.ticker);
+            tag = display_to_dp(
+                receivable.amount,
+                SHOW_TO_DP,
+                &data.coin.multiplier,
+                &data.coin.ticker,
+            );
             if receivable.message.is_some() {
                 tag = format!("{} + Msg", tag);
             }
@@ -636,210 +338,6 @@ fn show_inbox(s: &mut Cursive) {
         });
     }
     s.set_user_data(data);
-}
-
-fn show_message_info(s: &mut Cursive, _name: &str) {
-    let select = s.find_name::<SelectView<String>>("select").unwrap();
-    match select.selected_id() {
-        None => s.add_layer(Dialog::info("No receivable selected.")),
-        Some(focus) => {
-            let data = &mut s.user_data::<Data>().unwrap();
-            let receivable = &mut data.account.receivables[focus];
-            let private_key = &data.account.private_key;
-            let node_url = &data.node_url;
-            let plaintext: String;
-
-            let mut content = LinearLayout::vertical();
-            let mut title = format!("{} Receivable", &data.ticker);
-            let mut receive_label = String::from("");
-            if receivable.message.is_some() {
-                receive_label = String::from(" and mark read");
-                title = String::from("Message");
-                let mut message = receivable.message.as_mut().unwrap();
-                if message.plaintext.is_empty() {
-                    // Potential feature: Confirm option with message length in chars (estimated)
-                    // removes ability for attacks such as extremely long messages although probably
-                    // not an issue. Harder to send a long message than read.
-                    let target = &message.head.contents.account;
-                    let root_hash = &message.root_hash;
-                    let blocks = message.blocks;
-                    // Potential feature: Add loading screen + process_message()
-                    // time taken to load a (long) message can be noticeable if node
-                    // is under load.
-                    plaintext = read_message(private_key, target, root_hash, blocks, node_url);
-                    message.plaintext = plaintext.clone();
-                } else {
-                    plaintext = message.plaintext.clone();
-                }
-                content.add_child(
-                    TextView::new(plaintext)
-                        .scrollable()
-                        .max_width(80)
-                        .max_height(6),
-                );
-                content.add_child(DummyView);
-            }
-            let colour = data.colour;
-            if !(receivable.amount == 1 && receivable.message.is_some()) {
-                receive_label = format!("Receive{}", receive_label);
-                let amount = display_to_dp(receivable.amount, SHOW_TO_DP, &data.multiplier, &data.ticker);
-                content.add_child(TextView::new(StyledString::styled("Amount", colour)));
-                content.add_child(TextView::new(StyledString::styled(amount, OFF_WHITE)));
-                content.add_child(DummyView);
-            } else {
-                receive_label = String::from("Mark read");
-            }
-            let sender = receivable.source.clone();
-            content.add_child(TextView::new(StyledString::styled("From", colour)));
-            content
-                .add_child(TextView::new(StyledString::styled(&sender, OFF_WHITE)).fixed_width(65));
-
-            s.add_layer(
-                Dialog::around(content)
-                    .button(receive_label, move |s| {
-                        process_receive(s, focus);
-                    })
-                    .button("Copy address", move |s| copy_to_clip(s, sender.clone()))
-                    .button("Back", |s| go_back(s))
-                    .title(title),
-            );
-        }
-    }
-}
-
-fn get_mnemonic(s: &mut Cursive) {
-    s.pop_layer();
-    s.add_layer(
-        Dialog::new()
-            .title("Enter your 24 word mnemonic")
-            .padding_lrtb(1, 1, 1, 0)
-            .content(
-                EditView::new()
-                    .on_submit(set_mnemonic)
-                    .with_name("mnemonic")
-                    .fixed_width(29),
-            )
-            .h_align(HAlign::Center)
-            .button("Done", |s| {
-                let mnemonic = s
-                    .call_on_name("mnemonic", |view: &mut EditView| view.get_content())
-                    .unwrap();
-
-                set_mnemonic(s, &mnemonic);
-            })
-            .button("Paste", |s| {
-                s.call_on_name("mnemonic", |view: &mut EditView| {
-                    let mut clipboard = Clipboard::new().unwrap();
-                    let clip = clipboard
-                        .get_text()
-                        .unwrap_or_else(|_| String::from("Failed to read clipboard."));
-                    view.set_content(clip);
-                })
-                .unwrap();
-            })
-            .button("Back", |s| {
-                show_start(s);
-            }),
-    );
-}
-
-fn get_seed(s: &mut Cursive) {
-    s.pop_layer();
-    s.add_layer(
-        Dialog::new()
-            .title("Enter your hex seed")
-            .padding_lrtb(1, 1, 1, 0)
-            .content(
-                EditView::new()
-                    .on_submit(set_mnemonic)
-                    .with_name("seed")
-                    .fixed_width(29),
-            )
-            .h_align(HAlign::Center)
-            .button("Done", |s| {
-                let raw_seed = s
-                    .call_on_name("seed", |view: &mut EditView| view.get_content())
-                    .unwrap();
-                let seed = raw_seed.trim();
-                if seed.len() != 64 {
-                    s.add_layer(Dialog::info("Seed was invalid: not 64 characters long."));
-                    return;
-                }
-                let bytes_opt = hex::decode(seed);
-                if bytes_opt.is_err() {
-                    s.add_layer(Dialog::info("Seed was invalid: failed to decode hex."));
-                    return;
-                }
-                let bytes = bytes_opt.unwrap();
-                set_seed(s, bytes);
-            })
-            .button("Paste", |s| {
-                s.call_on_name("seed", |view: &mut EditView| {
-                    let mut clipboard = Clipboard::new().unwrap();
-                    let clip = clipboard
-                        .get_text()
-                        .unwrap_or_else(|_| String::from("Failed to read clipboard."));
-                    view.set_content(clip);
-                })
-                .unwrap();
-            })
-            .button("Back", |s| {
-                show_start(s);
-            }),
-    );
-}
-
-fn set_seed(s: &mut Cursive, seed: Vec<u8>) {
-    let mut entropy_bytes = [0u8; 32];
-    entropy_bytes.copy_from_slice(seed.as_slice());
-    s.pop_layer();
-    setup_account(s, entropy_bytes);
-    let content = "Successfully imported account.";
-    s.add_layer(Dialog::around(TextView::new(content)).button("Begin", |s| alpha_info(s)));
-}
-
-fn new_account(s: &mut Cursive) {
-    let mut csprng = rand::thread_rng();
-    let mut entropy_bytes = [0u8; 32];
-    csprng.fill_bytes(&mut entropy_bytes);
-    let entropy_hex = hex::encode(entropy_bytes);
-    setup_account(s, entropy_bytes);
-    s.pop_layer();
-    let mut content = StyledString::plain("Successfully generated new account with seed: ");
-    content.append(StyledString::styled(&entropy_hex, OFF_WHITE));
-    s.add_layer(
-        Dialog::around(TextView::new(content))
-            .button("Copy seed", move |s| copy_to_clip(s, entropy_hex.clone()))
-            .button("Begin", |s| alpha_info(s)),
-    );
-}
-
-fn setup_account(s: &mut Cursive, entropy_bytes: [u8; 32]) {
-    let data = &mut s.user_data::<Data>().unwrap();
-    let private_key_bytes = get_private_key(&entropy_bytes);
-    let private_key = ed25519_dalek::SecretKey::from_bytes(&private_key_bytes).unwrap();
-    let public_key = ed25519_dalek::PublicKey::from(&private_key);
-    let public_key_bytes = public_key.to_bytes();
-    let address = get_address(&public_key_bytes, &data.prefix);
-    data.account.entropy = entropy_bytes;
-    data.account.private_key = private_key_bytes;
-    data.account.public_key = public_key_bytes;
-    data.account.address = address;
-}
-
-fn set_mnemonic(s: &mut Cursive, mnemonic: &str) {
-    let entropy = validate_mnemonic(mnemonic);
-    let content;
-    s.pop_layer();
-    if !mnemonic.is_empty() && entropy.is_some() {
-        let entropy_bytes = entropy.unwrap();
-        setup_account(s, entropy_bytes);
-        content = "Successfully imported account.";
-        s.add_layer(Dialog::around(TextView::new(content)).button("Begin", |s| alpha_info(s)));
-    } else {
-        content = "The mnemonic you entered was not valid.";
-        s.add_layer(Dialog::around(TextView::new(content)).button("Back", |s| get_mnemonic(s)));
-    }
 }
 
 fn set_theme(s: &mut Cursive, style: &str, vibrant: bool) {

--- a/src/receive.rs
+++ b/src/receive.rs
@@ -1,0 +1,160 @@
+use super::*;
+
+pub fn show_message_info(s: &mut Cursive, _name: &str) {
+    let select = s.find_name::<SelectView<String>>("select").unwrap();
+    match select.selected_id() {
+        None => s.add_layer(Dialog::info("No receivable selected.")),
+        Some(focus) => {
+            let data = &mut s.user_data::<UserData>().unwrap();
+            let account = &mut data.accounts[data.acc_idx];
+            let receivable = &mut account.receivables[focus];
+            let private_key = &account.private_key;
+            let node_url = &data.coin.node_url;
+            let plaintext: String;
+
+            let mut content = LinearLayout::vertical();
+            let mut title = format!("{} Receivable", &data.coin.ticker);
+            let mut receive_label = String::from("");
+            if receivable.message.is_some() {
+                receive_label = String::from(" and mark read");
+                title = String::from("Message");
+                let mut message = receivable.message.as_mut().unwrap();
+                if message.plaintext.is_empty() {
+                    // Potential feature: Confirm option with message length in chars (estimated)
+                    // removes ability for attacks such as extremely long messages although probably
+                    // not an issue. Harder to send a long message than read.
+                    let target = &message.head.contents.account;
+                    let root_hash = &message.root_hash;
+                    let blocks = message.blocks;
+                    // Potential feature: Add loading screen + process_message()
+                    // time taken to load a (long) message can be noticeable if node
+                    // is under load.
+                    plaintext = read_message(private_key, target, root_hash, blocks, node_url);
+                    message.plaintext = plaintext.clone();
+                } else {
+                    plaintext = message.plaintext.clone();
+                }
+                content.add_child(
+                    TextView::new(plaintext)
+                        .scrollable()
+                        .max_width(80)
+                        .max_height(6),
+                );
+                content.add_child(DummyView);
+            }
+            let colour = data.coin.colour;
+            if !(receivable.amount == 1 && receivable.message.is_some()) {
+                receive_label = format!("Receive{}", receive_label);
+                let amount = display_to_dp(
+                    receivable.amount,
+                    SHOW_TO_DP,
+                    &data.coin.multiplier,
+                    &data.coin.ticker,
+                );
+                content.add_child(TextView::new(StyledString::styled("Amount", colour)));
+                content.add_child(TextView::new(StyledString::styled(amount, OFF_WHITE)));
+                content.add_child(DummyView);
+            } else {
+                receive_label = String::from("Mark read");
+            }
+            let sender = receivable.source.clone();
+            content.add_child(TextView::new(StyledString::styled("From", colour)));
+            content
+                .add_child(TextView::new(StyledString::styled(&sender, OFF_WHITE)).fixed_width(65));
+
+            s.add_layer(
+                Dialog::around(content)
+                    .button(receive_label, move |s| {
+                        process_receive(s, focus);
+                    })
+                    .button("Copy address", move |s| copy_to_clip(s, sender.clone()))
+                    .button("Back", |s| go_back(s))
+                    .title(title),
+            );
+        }
+    }
+}
+
+pub fn load_receivables(s: &mut Cursive) {
+    let ticks = 1000;
+
+    let cb = s.cb_sink().clone();
+
+    let data = &s.user_data::<UserData>().unwrap();
+    let node_url = data.coin.node_url.clone();
+    let target_address = data.accounts[data.acc_idx].address.clone();
+    s.pop_layer();
+    s.add_layer(Dialog::around(
+        ProgressBar::new()
+            .range(0, ticks)
+            .with_task(move |counter| {
+                let account_info = get_account_info(&target_address, &node_url);
+                let mut balance: u128 = 0;
+                if account_info.is_some() {
+                    balance = get_balance(&account_info.unwrap());
+                }
+                counter.tick(100);
+                let receivables = find_incoming(&target_address, &node_url, &counter);
+                cb.send(Box::new(move |s| {
+                    let data = &mut s.user_data::<UserData>().unwrap();
+                    let mut account = &mut data.accounts[data.acc_idx];
+                    account.receivables = receivables;
+                    account.balance = balance;
+                    show_inbox(s);
+                }))
+                .unwrap();
+            })
+            .full_width(),
+    ));
+    s.set_autorefresh(true);
+}
+
+fn process_receive(s: &mut Cursive, idx: usize) {
+    let data = &s.user_data::<UserData>().unwrap();
+    let private_key = data.accounts[data.acc_idx].private_key;
+    let send_block_hash = data.accounts[data.acc_idx].receivables[idx].hash.clone();
+    let amount = data.accounts[data.acc_idx].receivables[idx].amount;
+    let address = data.accounts[data.acc_idx].address.clone();
+    let prefix = data.coin.prefix.clone();
+    let node_url = data.coin.node_url.clone();
+    let ticks = 1000;
+    let cb = s.cb_sink().clone();
+    s.add_layer(Dialog::around(
+        ProgressBar::new()
+            .range(0, ticks)
+            .with_task(move |counter| {
+                counter.tick(100);
+                receive_block(
+                    &private_key,
+                    &send_block_hash,
+                    amount,
+                    &address,
+                    &node_url,
+                    &prefix,
+                    &counter,
+                );
+                cb.send(Box::new(move |s| {
+                    let mut select = s.find_name::<SelectView<String>>("select").unwrap();
+                    select.remove_item(idx);
+                    let mut balance = s.find_name::<TextView>("balance").unwrap();
+                    let data = &mut s.user_data::<UserData>().unwrap();
+                    let account = &mut data.accounts[data.acc_idx];
+                    account.receivables.remove(idx);
+                    account.balance += amount;
+                    let bal = display_to_dp(
+                        account.balance,
+                        SHOW_TO_DP,
+                        &data.coin.multiplier,
+                        &data.coin.ticker,
+                    );
+                    let bal_text = format!("Balance: {}", bal);
+                    balance.set_content(StyledString::styled(bal_text, data.coin.colour));
+                    s.pop_layer();
+                    s.pop_layer();
+                }))
+                .unwrap();
+            })
+            .full_width(),
+    ));
+    s.set_autorefresh(true);
+}

--- a/src/send.rs
+++ b/src/send.rs
@@ -1,0 +1,228 @@
+use super::*;
+
+pub fn show_send(s: &mut Cursive, with_message: bool) {
+    s.pop_layer();
+
+    let data = &s.user_data::<UserData>().unwrap();
+    let balance = data.accounts[data.acc_idx].balance;
+    let coin = data.coin.name.clone();
+    let ticker = data.coin.ticker.clone();
+    let multiplier = data.coin.multiplier.clone();
+
+    if balance == 0 {
+        let address = data.accounts[data.acc_idx].address.clone();
+        let no_balance_message;
+        if with_message {
+            no_balance_message = format!("To send a message with dagchat you need a balance of at least 1 raw - a tiny fraction of a coin. One faucet claim will last you a lifetime. Your address is: {}", address);
+        } else {
+            no_balance_message = format!("You don't have any {} in your wallet to send.", coin);
+        }
+        s.add_layer(
+            Dialog::around(TextView::new(no_balance_message))
+                .h_align(HAlign::Center)
+                .button("Back", |s| show_inbox(s))
+                .button("Copy Address", move |s| copy_to_clip(s, address.clone()))
+                .max_width(75),
+        );
+        return;
+    }
+
+    let sub_title_colour = get_subtitle_colour(s);
+
+    let mut form_content = LinearLayout::vertical()
+        .child(TextView::new(StyledString::styled(
+            "Recipient Address",
+            sub_title_colour,
+        )))
+        .child(TextArea::new().with_name("address").max_width(66))
+        .child(
+            LinearLayout::horizontal()
+                .child(Button::new("Paste", |s| {
+                    s.call_on_name("address", |view: &mut TextArea| {
+                        let mut clipboard = Clipboard::new().unwrap();
+                        let clip = clipboard
+                            .get_text()
+                            .unwrap_or_else(|_| String::from("Failed to read clipboard."));
+                        view.set_content(clip);
+                    })
+                    .unwrap();
+                }))
+                .child(Button::new("Address book", |s| {
+                    s.add_layer(Dialog::info("Coming soon..."));
+                })),
+        )
+        .child(DummyView);
+    let title_content;
+    if with_message {
+        title_content = String::from("Send a message");
+        form_content.add_child(TextView::new(StyledString::styled(
+            "Message Content",
+            sub_title_colour,
+        )));
+        form_content.add_child(TextArea::new().with_name("message").max_width(80));
+        form_content.add_child(DummyView);
+        form_content.add_child(TextView::new(StyledString::styled(
+            format!("Optional {}", ticker),
+            sub_title_colour,
+        )));
+        form_content.add_child(TextArea::new().with_name("amount"));
+    } else {
+        title_content = format!("Send {}", coin);
+        form_content.add_child(TextView::new(StyledString::styled(
+            "Amount",
+            sub_title_colour,
+        )));
+        form_content.add_child(TextArea::new().with_name("amount"));
+    }
+    form_content.add_child(DummyView);
+    form_content.add_child(
+        LinearLayout::horizontal()
+            .child(Button::new("Send", move |s| {
+                let mut address = String::from("");
+                let mut message = String::from("");
+                let mut amount = String::from("");
+                s.call_on_name("address", |view: &mut TextArea| {
+                    address = String::from(view.get_content());
+                })
+                .unwrap();
+                if with_message {
+                    s.call_on_name("message", |view: &mut TextArea| {
+                        message = String::from(view.get_content());
+                    })
+                    .unwrap();
+                    if message.trim().is_empty() {
+                        s.add_layer(Dialog::info(
+                            "You must provide message content to send a message!",
+                        ));
+                        return;
+                    }
+                }
+                s.call_on_name("amount", |view: &mut TextArea| {
+                    amount = String::from(view.get_content());
+                })
+                .unwrap();
+                if address.is_empty() {
+                    let content;
+                    if with_message {
+                        content =
+                            String::from("You must provide an address to send the message to!");
+                    } else {
+                        content = format!("You must provide an address to send {} to!", coin);
+                    }
+                    s.add_layer(Dialog::info(content));
+                    return;
+                }
+                let valid = validate_address(&address);
+                if !valid {
+                    s.add_layer(Dialog::info("The recipient's address is invalid."));
+                    return;
+                }
+                let mut raw: u128 = 0;
+                if with_message {
+                    raw = 1;
+                }
+                if !amount.is_empty() {
+                    let raw_opt = whole_to_raw(amount, &multiplier);
+                    if raw_opt.is_none() {
+                        let content;
+                        if with_message {
+                            content = "The optional amount was invalid.";
+                        } else {
+                            content = "The amount was invalid.";
+                        }
+                        s.add_layer(Dialog::info(content));
+                        return;
+                    }
+                    raw = raw_opt.unwrap();
+                    if raw > balance {
+                        s.add_layer(Dialog::info(
+                            "The amount you want to send is more than your account balance!",
+                        ));
+                        return;
+                    } else {
+                        // The user supplied the amount 0
+                        if raw == 0 {
+                            s.add_layer(Dialog::info(format!(
+                                "You must provide an amount of {} to send!",
+                                coin
+                            )));
+                            return;
+                        }
+                    }
+                } else {
+                    if message.is_empty() {
+                        // The user supplied no amount and it's not a message
+                        s.add_layer(Dialog::info(format!(
+                            "You must provide an amount of {} to send!",
+                            coin
+                        )));
+                        return;
+                    }
+                }
+                process_send(s, raw, address, message);
+            }))
+            .child(Button::new("Back", |s| show_inbox(s))),
+    );
+    s.add_layer(
+        Dialog::around(form_content)
+            .title(title_content)
+            .padding_lrtb(1, 1, 1, 0),
+    );
+}
+
+pub fn show_sent(s: &mut Cursive, with_message: bool) {
+    s.set_autorefresh(false);
+    s.pop_layer();
+    let content;
+    if with_message {
+        content = "Message sent successfully!";
+    } else {
+        content = "Sent successfully!";
+    }
+    s.add_layer(Dialog::text(content).button("Back", |s| show_inbox(s)));
+}
+
+fn process_send(s: &mut Cursive, raw: u128, address: String, message: String) {
+    let ticks = 1000;
+    let cb = s.cb_sink().clone();
+    let data = &mut s.user_data::<UserData>().unwrap();
+    let node_url = data.coin.node_url.clone();
+    let private_key_bytes = data.accounts[data.acc_idx].private_key;
+    let prefix = data.coin.prefix.clone();
+    s.pop_layer();
+    s.add_layer(Dialog::around(
+        ProgressBar::new()
+            .range(0, ticks)
+            .with_task(move |counter| {
+                let with_message = !message.is_empty();
+                if !with_message {
+                    send(
+                        &private_key_bytes,
+                        address,
+                        raw,
+                        &node_url,
+                        &prefix,
+                        &counter,
+                    );
+                } else {
+                    send_message(
+                        &private_key_bytes,
+                        address,
+                        raw,
+                        message,
+                        &node_url,
+                        &prefix,
+                        &counter,
+                    );
+                }
+                cb.send(Box::new(move |s| {
+                    let data = &mut s.user_data::<UserData>().unwrap();
+                    data.accounts[data.acc_idx].balance -= raw;
+                    show_sent(s, with_message);
+                }))
+                .unwrap();
+            })
+            .full_width(),
+    ));
+    s.set_autorefresh(true);
+}


### PR DESCRIPTION
Potentially unstable. Work in progress, not yet bug tested or polished.

### Added 
1. Accounts are saved under OS default application data directory and then /dagchat/accounts.dagchat
2. Account data is encrypted using a user passphrase
3. File structure rework

### Process used for encrypting account data using passphrase
1. Expand passphrase into 256 bit key using Argon2 with randomly generated 128 bit salt
2. Serialise UserData's Vec<Account> with bincode into Vec<u8>
3. Encrypt this Vec<u8> with 256 bit key from 1. using AES256gcm
4. Concatenate salt, nonce, and encrypted bytes in that order
5. Write to [OS App data]/dagchat/accounts.dagchat

