### PR TITLE
Trim sending address

### DIFF
--- a/src/app/components/send/ui/primary.rs
+++ b/src/app/components/send/ui/primary.rs
@@ -156,6 +156,7 @@ pub fn show_send(s: &mut Cursive, with_message: bool) {
                     s.add_layer(Dialog::info(content));
                     return;
                 }
+                address = address.trim().to_string();
                 if !validate_address(&address) {
                     s.add_layer(Dialog::info("The recipient's address is invalid."));
                     return;

--- a/src/app/components/send/ui/primary.rs
+++ b/src/app/components/send/ui/primary.rs
@@ -128,7 +128,7 @@ pub fn show_send(s: &mut Cursive, with_message: bool) {
                 let mut message = String::from("");
                 let mut amount = String::from("");
                 s.call_on_name("address", |view: &mut TextArea| {
-                    address = String::from(view.get_content());
+                    address = String::from(view.get_content().trim());
                 })
                 .unwrap();
                 if with_message {
@@ -156,7 +156,6 @@ pub fn show_send(s: &mut Cursive, with_message: bool) {
                     s.add_layer(Dialog::info(content));
                     return;
                 }
-                address = address.trim().to_string();
                 if !validate_address(&address) {
                     s.add_layer(Dialog::info("The recipient's address is invalid."));
                     return;


### PR DESCRIPTION
When pasting, sometimes there may be a space at the end of the address. dagchat will now trim the address that the user pastes when sending messages/banano. Tested with `cargo build --release`, and pasting in an address with a space in the send dialog. It should work.